### PR TITLE
change: make BitcoinScript.Parse() not panicing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Golang module that helps you answer questions about raw bitcoin transactions, 
 
 ### Transactions
 
-Transactions can be deserialized [from a hex string][50] or [from][51] a [wire.MsgTx][52]. 
+Transactions can be deserialized [from a hex string][50] or [from][51] a [wire.MsgTx][52].
 Based on that following questions can be answered.
 
 - [x] [How many inputs?][60]
@@ -44,7 +44,7 @@ Based on that following questions can be answered.
 [71]: https://www.godoc.org/github.com/0xb10c/rawtx/#Tx.GetSizeWithWitness
 [72]: https://www.godoc.org/github.com/0xb10c/rawtx/#Tx.GetSizeWithoutWitness
 
-### Input and Output type 
+### Input and Output type
 
 - [x] [What type has this input?][24]
 - [x] [What type has this output?][25]
@@ -101,24 +101,24 @@ It has a `String()` method which displays the OP codes in a bitcoin developer re
 
 ```go away
 bs1 := BitcoinScript{0x6e, 0x87, 0x91, 0x69, 0xa7, 0x7c, 0xa7, 0x87}
-pbs1 := bs1.ParseWithPanic()
+pbs1 := bs1.Parse()
 fmt.Println(pbs1.String())
 // -> OP_2DUP OP_EQUAL OP_NOT OP_VERIFY OP_SHA1 OP_SWAP OP_SHA1 OP_EQUAL
 ```
 
 ```go awayy
 bs2 = BitcoinScript{byte(OpRETURN), byte(OpDATA2), byte(OpCHECKLOCKTIMEVERIFY), byte(OpDATA12)}
-pbs2 = bs2.ParseWithPanic()
+pbs2 = bs2.Parse()
 fmt.Println(pbs2.String())
 // -> OP_RETURN OP_DATA_2(b10c)
 ```
 
-The actual [OpCode][33] behind the ParsedOpCode can, but doesn't have to push data. You can check if a ParsedOpCode is 
+The actual [OpCode][33] behind the ParsedOpCode can, but doesn't have to push data. You can check if a ParsedOpCode is
 - [x] a [signature?][34] (and [what's the SigHash?][37])
 - [x] a [compressed public key?][35]
 - [x] an [uncompressed public key?][36]
 - [x] or either a [compressed or uncompressed public key?][38]
-- [x] or compare it any other OpCode.  
+- [x] or compare it any other OpCode.
 
 [30]: https://www.godoc.org/github.com/0xb10c/rawtx/#BitcoinScript
 [31]: https://www.godoc.org/github.com/0xb10c/rawtx/#ParsedBitcoinScript

--- a/input_test.go
+++ b/input_test.go
@@ -31,7 +31,7 @@ func TestInputSpendsNativeSegWit(t *testing.T) {
 			result := in.SpendsNativeSegWit()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsNativeSegWit==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -65,7 +65,7 @@ func TestSpendsNestedSegWit(t *testing.T) {
 			result := in.SpendsNestedSegWit()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsNestedSegWit==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -98,7 +98,7 @@ func TestSpendsNestedP2WPKH(t *testing.T) {
 			result := in.SpendsNestedP2WPKH()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsNestedP2WPKH==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -132,7 +132,7 @@ func TestSpendsNestedP2WSH(t *testing.T) {
 			result := in.SpendsNestedP2WSH()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsNestedP2WSH==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -167,7 +167,7 @@ func TestSpendsP2PKH(t *testing.T) {
 			result := in.SpendsP2PKH()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsP2PKH==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -192,7 +192,7 @@ func TestSpendsP2PKHWithIsCompressed(t *testing.T) {
 			spends, compressed := in.SpendsP2PKHWithIsCompressed()
 			if spends != expexted[index][0] || compressed != expexted[index][1] {
 				t.Errorf("Expexted SpendsP2PKHWithIsCompressed=={%v} at index %d, but got {%t,%t}", expexted[index], index, spends, compressed)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -229,7 +229,7 @@ func TestSpendsP2PK(t *testing.T) {
 			result := in.SpendsP2PK()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsP2PK==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -261,7 +261,7 @@ func TestSpendsP2SH(t *testing.T) {
 			result := in.SpendsP2SH()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsP2SH==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -323,7 +323,7 @@ func TestSpendsP2WPKH(t *testing.T) {
 			result := in.SpendsP2WPKH()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsP2WPKH==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -360,7 +360,7 @@ func TestSpendsP2MS(t *testing.T) {
 			result := in.SpendsP2MS()
 			if result != expexted[index] {
 				t.Errorf("Expexted SpendsP2MS==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -398,7 +398,7 @@ func TestIsLNUniliteralClosing(t *testing.T) {
 			result := in.IsLNUniliteralClosing()
 			if result != expexted[index] {
 				t.Errorf("Expexted IsLNChannelClosing==%t at index %d, but got %t", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}
@@ -439,7 +439,7 @@ func TestInputGetType(t *testing.T) {
 			result := in.GetType()
 			if result != expexted[index] {
 				t.Errorf("Expexted GetType==%s at index %d, but got %s", expexted[index], index, result)
-				pbs := in.ScriptSig.ParseWithPanic()
+				pbs := in.ScriptSig.Parse()
 				t.Errorf("input script sig: %s", pbs.String())
 			}
 		}

--- a/opcodes.go
+++ b/opcodes.go
@@ -1,6 +1,6 @@
 package rawtx
 
-// OpCode represents a bitcoin operation code
+// OpCode represents a Bitcoin operation code
 type OpCode byte
 
 // Bitcoin OP Codes.
@@ -523,4 +523,12 @@ var OpCodeStringMap = map[OpCode]string{
 	OpPUBKEYHASH:          "OP_PUBKEYHASH",
 	OpPUBKEY:              "OP_PUBKEY",
 	OpINVALIDOPCODE:       "OP_INVALIDOPCODE",
+}
+
+// IsDataPushOpCode indicates if a opCode pushes data to the stack
+func (opCode OpCode) IsDataPushOpCode() bool {
+	return (opCode >= OpDATA1 && opCode <= OpDATA75) ||
+		opCode == OpPUSHDATA1 ||
+		opCode == OpPUSHDATA2 ||
+		opCode == OpPUSHDATA4
 }

--- a/output.go
+++ b/output.go
@@ -75,7 +75,7 @@ func (out *Output) GetType() OutputType {
 //  OP_RETURN <SomeDataPush> <OP_RETURN data>
 func (out *Output) IsOPReturnOutput() (is bool) {
 	if len(out.ScriptPubKey) > 0 {
-		pbs := out.ScriptPubKey.ParseWithPanic()
+		pbs := out.ScriptPubKey.Parse()
 		if pbs[0].OpCode == OpRETURN {
 			return true
 		}
@@ -89,7 +89,7 @@ func (out *Output) IsOPReturnOutput() (is bool) {
 //  OP_RETURN <SomeDataPush> <OP_RETURN data>
 func (out *Output) GetOPReturnData() (bool, ParsedOpCode) {
 	if out.IsOPReturnOutput() {
-		pbs := out.ScriptPubKey.ParseWithPanic()
+		pbs := out.ScriptPubKey.Parse()
 		return true, pbs[1]
 	}
 	return false, ParsedOpCode{}
@@ -100,7 +100,7 @@ func (out *Output) GetOPReturnData() (bool, ParsedOpCode) {
 //  OP_DUP OP_HASH160 OP_DATA_20(20 byte pubKeyHash) OP_EQUALVERIFY OP_CHECKSIG
 //  OP_DUP OP_HASH160 OP_DATA_20(                  ) OP_EQUALVERIFY OP_CHECKSIG
 func (out *Output) IsP2PKHOutput() bool {
-	pbs := out.ScriptPubKey.ParseWithPanic()
+	pbs := out.ScriptPubKey.Parse()
 	if len(pbs) == 5 {
 		if pbs[0].OpCode == OpDUP && // OP_DUP
 			pbs[1].OpCode == OpHASH160 && // OP_HASH160
@@ -117,7 +117,7 @@ func (out *Output) IsP2PKHOutput() bool {
 // A P2SH scriptPubKey looks like:
 //  OP_HASH160 OP_DATA_20(20 byte hash) OP_EQUAL
 func (out *Output) IsP2SHOutput() bool {
-	pbs := out.ScriptPubKey.ParseWithPanic()
+	pbs := out.ScriptPubKey.Parse()
 	if len(pbs) == 3 {
 		if pbs[0].OpCode == OpHASH160 &&
 			pbs[1].OpCode == OpDATA20 && // FIXME: could also be inefficient with OpPUSHDATA1 / 2 / 4  ?
@@ -132,7 +132,7 @@ func (out *Output) IsP2SHOutput() bool {
 // A P2WPKH V0 output looks like:
 //  OP_0 OP_DATA_20(20 byte hash) (where the leading OP_0 indicates witness program 0)
 func (out *Output) IsP2WPKHV0Output() bool {
-	pbs := out.ScriptPubKey.ParseWithPanic()
+	pbs := out.ScriptPubKey.Parse()
 	if len(pbs) == 2 {
 		if pbs[0].OpCode == Op0 && // witness program 0
 			pbs[1].OpCode == OpDATA20 { // OP_DATA_20 // FIXME: could also be inefficient with OpPUSHDATA1 / 2 / 4  ?
@@ -146,7 +146,7 @@ func (out *Output) IsP2WPKHV0Output() bool {
 // A P2WSH V0 output looks like:
 //  OP_0 (as witness program 0) OP_DATA_32(32 byte hash)
 func (out *Output) IsP2WSHV0Output() bool {
-	pbs := out.ScriptPubKey.ParseWithPanic()
+	pbs := out.ScriptPubKey.Parse()
 	if len(pbs) == 2 {
 		if pbs[0].OpCode == Op0 && // witness program 0
 			pbs[1].OpCode == OpDATA32 { // OP_DATA_32 // FIXME: could also be inefficient with OpPUSHDATA1 / 2 / 4  ?
@@ -167,7 +167,7 @@ func (out *Output) IsP2MSOutput() (is bool, m int, n int) {
 // A P2PK output looks like:
 //  PubKey OP_CHECKSIG
 func (out *Output) IsP2PKOutput() bool {
-	pbs := out.ScriptPubKey.ParseWithPanic()
+	pbs := out.ScriptPubKey.Parse()
 	if len(pbs) == 2 {
 		if pbs[0].IsPubKey() && pbs[1].OpCode == OpCHECKSIG {
 			return true

--- a/output_test.go
+++ b/output_test.go
@@ -29,7 +29,7 @@ func TestIsOPReturnOutput(t *testing.T) {
 			result := out.IsOPReturnOutput()
 			if result != expexted[index] {
 				t.Errorf("Expexted IsOPReturnOutput==%t at index %d, but got %t", expexted[index], index, result)
-				ps := out.ScriptPubKey.ParseWithPanic()
+				ps := out.ScriptPubKey.Parse()
 				t.Errorf("input scriptPubKey: %s", ps.String())
 			}
 		}
@@ -70,7 +70,7 @@ func TestGetOPReturnData(t *testing.T) {
 			is, opcode := out.GetOPReturnData()
 			if is != expexted[index].Is || len(opcode.PushedData) != expexted[index].Length || (len(opcode.PushedData) > 0 && opcode.PushedData[len(opcode.PushedData)-1] != expexted[index].LastByte) {
 				t.Errorf("Expexted GetOPReturnData==%v at index %d, but got [%t, %d, %d]", expexted[index], index, is, len(opcode.PushedData), opcode.PushedData[len(opcode.PushedData)-1])
-				ps := out.ScriptPubKey.ParseWithPanic()
+				ps := out.ScriptPubKey.Parse()
 				t.Errorf("input scriptPubKey: %s", ps.String())
 			}
 		}
@@ -103,7 +103,7 @@ func TestIsP2PKHOutput(t *testing.T) {
 			result := out.IsP2PKHOutput()
 			if result != expexted[index] {
 				t.Errorf("Expexted IsP2PKHOutput==%t at index %d, but got %t", expexted[index], index, result)
-				ps := out.ScriptPubKey.ParseWithPanic()
+				ps := out.ScriptPubKey.Parse()
 				t.Errorf("input scriptPubKey: %s", ps.String())
 			}
 		}
@@ -137,7 +137,7 @@ func TestIsP2WPKHV0Output(t *testing.T) {
 			result := out.IsP2WPKHV0Output()
 			if result != expexted[index] {
 				t.Errorf("Expexted IsP2WPKHOutput==%t at index %d, but got %t", expexted[index], index, result)
-				ps := out.ScriptPubKey.ParseWithPanic()
+				ps := out.ScriptPubKey.Parse()
 				t.Errorf("input scriptPubKey: %s", ps.String())
 			}
 		}
@@ -170,7 +170,7 @@ func TestIsP2SHOutput(t *testing.T) {
 			result := out.IsP2SHOutput()
 			if result != expexted[index] {
 				t.Errorf("Expexted IsP2SHOutput==%t at index %d, but got %t", expexted[index], index, result)
-				ps := out.ScriptPubKey.ParseWithPanic()
+				ps := out.ScriptPubKey.Parse()
 				t.Errorf("input scriptPubKey: %s", ps.String())
 			}
 		}
@@ -203,7 +203,7 @@ func TestIsP2WSHV0Output(t *testing.T) {
 			result := out.IsP2WSHV0Output()
 			if result != expexted[index] {
 				t.Errorf("Expexted IsP2WSHOutput==%t at index %d, but got %t", expexted[index], index, result)
-				ps := out.ScriptPubKey.ParseWithPanic()
+				ps := out.ScriptPubKey.Parse()
 				t.Errorf("input scriptPubKey: %s", ps.String())
 			}
 		}
@@ -248,7 +248,7 @@ func TestIsP2MSOutput(t *testing.T) {
 			is, m, n := out.IsP2MSOutput()
 			if is != expexted[index].is || m != expexted[index].m || n != expexted[index].n {
 				t.Errorf("Expexted IsP2MSOutput==[%t, %d-of-%d] at index %d, but got [%t, %d-of-%d]", expexted[index].is, expexted[index].m, expexted[index].n, index, is, m, n)
-				ps := out.ScriptPubKey.ParseWithPanic()
+				ps := out.ScriptPubKey.Parse()
 				t.Errorf("input scriptPubKey: %s", ps.String())
 			}
 		}
@@ -277,7 +277,7 @@ func TestIsP2PKOutput(t *testing.T) {
 			result := out.IsP2PKOutput()
 			if result != expexted[index] {
 				t.Errorf("Expexted IsP2PKOutput==%t at index %d, but got %t", expexted[index], index, result)
-				ps := out.ScriptPubKey.ParseWithPanic()
+				ps := out.ScriptPubKey.Parse()
 				t.Errorf("input scriptPubKey: %s", ps.String())
 			}
 		}
@@ -320,7 +320,7 @@ func TestOutputGetType(t *testing.T) {
 			result := out.GetType()
 			if result != expexted[index] {
 				t.Errorf("Expexted GetType==%s at index %d, but got %s", expexted[index], index, result)
-				pbs := out.ScriptPubKey.ParseWithPanic()
+				pbs := out.ScriptPubKey.Parse()
 				t.Errorf("input script pub key: %s", pbs.String())
 			}
 		}


### PR DESCRIPTION
Previously the BitcoinScript.ParseWithPanic() would panic on script
data pushes that would push-after-end-off-script (i.e. the OpCode
would specify a push of more bytes than remaining in the script).
Since that's quite common in coinbase transactions the parser would
panic regularly.

This solves this by not panicing on these pushes. The ParsedOpCodes
just contain what is left from the script.

This is an API-breaking change.