### PR TITLE
add: txstats object

### DIFF
--- a/examples/txstat/README.md
+++ b/examples/txstat/README.md
@@ -1,0 +1,81 @@
+# Example txstats
+
+The file `txstat.go` contains a simple example usage of the rawtx `tx.Stats()` functionality.
+The `txstat` binary takes a raw transaction in hex as argument with `-raw` and prints a JSON object containing stats about the transaction.
+
+```terminal
+$ go run txstat.go -raw 0100000001c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd3704000000004847304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901ffffffff0200ca9a3b00000000434104ae1a62fe09c5f51b13905f07f06b99a2f7159b2225f374cd378d71302fa28414e7aab37397f554a7df5f142c21c1b7303b8a0626f1baded5c72a704f7e6cd84cac00286bee0000000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac00000000
+{
+  "TxID": "Fp4eg+kwhTORvG819gXGdUz+rVfPg4djnTtAlsVPGPQ=",
+  "TxIDString": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+  "Version": 1,
+  "Payments": 1,
+  "OutAmount": 5000000000,
+  "VSize": 275,
+  "Size": 275,
+  "IsCoinbase": false,
+  "IsSpendingSegWit": false,
+  "IsSpendingNativeSegWit": false,
+  "IsSpendingNestedSegWit": false,
+  "IsBIP69Compliant": true,
+  "IsExplicitlyRBFSignaling": false,
+  "Locktime": {
+    "Locktime": 0,
+    "IsEnforced": false,
+    "IsBlockHeight": true,
+    "IsTimestamp": false
+  },
+  "InStats": [
+    {
+      "Type": 1,
+      "TypeString": "P2PK",
+      "Sequence": 4294967295,
+      "IsSpendingSegWit": false,
+      "IsSpendingNativeSegWit": false,
+      "IsSpendingNestedSegWit": false,
+      "IsLNUniliteralClosing": false,
+      "IsSpendingMultisig": false,
+      "MultiSigM": 0,
+      "MultiSigN": 0,
+      "SigStats": [
+        {
+          "Length": 71,
+          "IsECDSA": true,
+          "IsStrictDER": true,
+          "HasLowR": true,
+          "HasLowS": true,
+          "SigHash": 1
+        }
+      ],
+      "PubKeyStats": [],
+      "OpCodes": "Rw=="
+    }
+  ],
+  "OutStats": [
+    {
+      "Type": 1,
+      "TypeString": "P2PK",
+      "Amount": 1000000000,
+      "OpReturnData": null,
+      "PubKeyStats": [
+        {
+          "IsCompressed": false
+        }
+      ],
+      "OpCodes": "Qaw="
+    },
+    {
+      "Type": 1,
+      "TypeString": "P2PK",
+      "Amount": 4000000000,
+      "OpReturnData": null,
+      "PubKeyStats": [
+        {
+          "IsCompressed": false
+        }
+      ],
+      "OpCodes": "Qaw="
+    }
+  ]
+}
+```

--- a/examples/txstat/txstat.go
+++ b/examples/txstat/txstat.go
@@ -1,0 +1,53 @@
+package main
+
+// This is a example to showcase the raw transaction stat functionality of rawtx
+// It takes a rawtx as hex string and prints a JSON object containing stats about the transaction
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/0xb10c/rawtx"
+	"github.com/btcsuite/btcd/wire"
+)
+
+func main() {
+	raw := flag.String("raw", "", "raw transaction in hex")
+	flag.Parse()
+
+	if len(*raw) == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	rawAsByteSlice, err := hex.DecodeString(*raw)
+	if err != nil {
+		fmt.Printf("Could not decode the raw transaction: %s\n", err)
+		os.Exit(2)
+	}
+
+	// rawtx depends on wire.MsgTx for deserializing the raw transaction
+	r := bytes.NewReader(rawAsByteSlice)
+	wireTx := &wire.MsgTx{}
+	err = wireTx.Deserialize(r)
+	if err != nil {
+		fmt.Printf("Could not deserialize the transaction: %s\n", err)
+		os.Exit(3)
+	}
+
+	tx := rawtx.Tx{}
+	tx.FromWireMsgTx(wireTx)
+
+	txstats := tx.Stats()
+	txstatJSON, err := json.MarshalIndent(txstats, "", "  ")
+	if err != nil {
+		fmt.Printf("Could not marshal txstats to JSON: %s\n", err)
+		os.Exit(4)
+	}
+
+	fmt.Println(string(txstatJSON))
+}

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495 h1:6IyqGr3fnd0tM3YxipK27TUskaOVUjU2nG45yzwcQKY=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/script.go
+++ b/script.go
@@ -12,6 +12,7 @@ import (
 type BitcoinScript []byte
 
 // ParsedOpCode respresents a OP Code as a part of a parsed BitcoinScript.
+// TODO: rename ito ParsedBitcoinScriptElement or something similar?
 type ParsedOpCode struct {
 	OpCode     OpCode
 	PushedData []byte
@@ -29,6 +30,28 @@ func (poc *ParsedOpCode) String() string {
 	}
 
 	return OpCodeStringMap[poc.OpCode]
+}
+
+// GetDataPushOpCodeForLength returns the optimal DataPush OpCode for the given data length
+// OpINVALIDOPCODE is returned for zero, negative or bigger than 0xffffffff inputs.
+func GetDataPushOpCodeForLength(length int) OpCode {
+	if length < 1 {
+		return OpINVALIDOPCODE
+	}
+
+	if length >= 1 && length <= 75 {
+		return OpCode(length)
+	}
+
+	if length > 75 && length <= 0xff {
+		return OpPUSHDATA1
+	} else if length > 0xff && length <= 0xffff {
+		return OpPUSHDATA2
+	} else if length > 0xffff && length <= 0xffffffff {
+		return OpPUSHDATA4
+	}
+
+	return OpINVALIDOPCODE
 }
 
 // ParsedBitcoinScript is a parsed BitcoinScript

--- a/testdata.go
+++ b/testdata.go
@@ -446,20 +446,5 @@ func GetTestTransactions() []TestTransaction {
 		},
 	}
 
-	/*
-		{
-			Note:        "",
-			RawTx:       "",
-			Size:        1111,
-			VSize:       999,
-			MultisigType:  []TestMultisigType{},
-			InputTypes:  []InputType{},
-			OutputTypes: []OutputType{},
-			Locktime:    888,
-			OutputSum:   777,
-			IsSpendingSegWit: xxx,
-		},
-	*/
-
 	return testTxns
 }

--- a/tx.go
+++ b/tx.go
@@ -12,7 +12,8 @@ import (
 
 // Tx represents a bitcoin transaction as a struct.
 type Tx struct {
-	Hash                  string
+	Hash                  []byte
+	HashString            string
 	Version               int32
 	Inputs                []Input
 	Outputs               []Output
@@ -29,7 +30,9 @@ func (tx *Tx) FromWireMsgTx(wireTx *wire.MsgTx) {
 	tx.serializeSize = wireTx.SerializeSize()
 	tx.serializeSizeStripped = wireTx.SerializeSizeStripped()
 	tx.bip69sorted = txsort.IsSorted(wireTx)
-	tx.Hash = wireTx.TxHash().String()
+	hash := wireTx.TxHash()
+	tx.Hash = hash.CloneBytes()
+	tx.HashString = hash.String()
 
 	for _, wireInput := range wireTx.TxIn {
 		in := Input{}

--- a/txstat.go
+++ b/txstat.go
@@ -1,0 +1,250 @@
+package rawtx
+
+// TxStats contains stats about a transaction.
+type TxStats struct {
+	TxID                     []byte
+	TxIDString               string
+	Version                  int32
+	Payments                 uint32
+	OutAmount                int64
+	VSize                    int
+	Size                     int
+	IsCoinbase               bool
+	IsSpendingSegWit         bool
+	IsSpendingNativeSegWit   bool
+	IsSpendingNestedSegWit   bool
+	IsBIP69Compliant         bool
+	IsExplicitlyRBFSignaling bool
+	Locktime                 *LocktimeStats
+	InStats                  []*InputStats
+	OutStats                 []*OutputStats
+}
+
+// Stats returns a *TxStats for the transaction
+func (tx *Tx) Stats() *TxStats {
+	txstats := &TxStats{}
+	txstats.TxID = tx.Hash
+	txstats.TxIDString = tx.HashString
+	txstats.Version = tx.Version
+	txstats.IsCoinbase = tx.IsCoinbase()
+	txstats.VSize = tx.GetSizeWithoutWitness()
+	txstats.Size = tx.GetSizeWithWitness()
+	txstats.IsSpendingNativeSegWit = tx.IsSpendingNativeSegWit()
+	txstats.IsSpendingNestedSegWit = tx.IsSpendingNestedSegWit()
+	txstats.IsSpendingSegWit = tx.IsSpendingSegWit()
+	txstats.IsBIP69Compliant = tx.IsBIP69Compliant()
+	txstats.IsExplicitlyRBFSignaling = tx.IsExplicitlyRBFSignaling()
+	txstats.Locktime = tx.LocktimeStats()
+
+	txstats.InStats = make([]*InputStats, 0)
+	for _, input := range tx.Inputs {
+		txstats.InStats = append(txstats.InStats, input.InputStats())
+	}
+
+	txstats.OutStats = make([]*OutputStats, 0)
+	for _, output := range tx.Outputs {
+		txstats.OutStats = append(txstats.OutStats, output.OutputStats())
+		txstats.OutAmount += output.Value
+	}
+
+	// The payments metric is defined as:
+	// number of outputs minus one change output if more than one output
+	txstats.Payments = uint32(len(txstats.OutStats))
+	if len(txstats.OutStats) > 1 {
+		txstats.Payments--
+	}
+
+	return txstats
+}
+
+// LocktimeStats contains stats about the transaction locktime
+type LocktimeStats struct {
+	Locktime      uint32
+	IsEnforced    bool
+	IsBlockHeight bool
+	IsTimestamp   bool
+}
+
+// LocktimeStats returns a populated *LocktimeStats struct for the transaction
+func (tx *Tx) LocktimeStats() *LocktimeStats {
+	locktimeStats := &LocktimeStats{}
+	locktimeStats.Locktime = tx.Locktime
+	locktimeStats.IsBlockHeight = (tx.Locktime < 500000000)
+	locktimeStats.IsTimestamp = (tx.Locktime >= 500000000)
+	for _, input := range tx.Inputs {
+		if input.Sequence < 0xffffffff {
+			locktimeStats.IsEnforced = true
+		}
+	}
+	return locktimeStats
+}
+
+// InputStats contains stats about a transaction input
+type InputStats struct {
+	Type                   InputType
+	TypeString             string
+	Sequence               uint32
+	IsSpendingSegWit       bool
+	IsSpendingNativeSegWit bool
+	IsSpendingNestedSegWit bool
+	IsLNUniliteralClosing  bool
+	IsSpendingMultisig     bool
+	MultiSigM              int
+	MultiSigN              int
+	SigStats               []*SignatureStats
+	PubKeyStats            []*PubKeyStats
+	OpCodes                []OpCode
+}
+
+// InputStats returns a populated *InputStats struct for the input
+func (input *Input) InputStats() *InputStats {
+	inputStats := &InputStats{}
+	inputStats.Type = input.GetType()
+	inputStats.TypeString = input.GetType().String()
+	inputStats.Sequence = input.Sequence
+	inputStats.IsSpendingNativeSegWit = input.SpendsNativeSegWit()
+	inputStats.IsSpendingNestedSegWit = input.SpendsNestedSegWit()
+	inputStats.IsSpendingSegWit = inputStats.IsSpendingNativeSegWit || inputStats.IsSpendingNestedSegWit
+	inputStats.IsLNUniliteralClosing = input.IsLNUniliteralClosing()
+	inputStats.IsSpendingMultisig = input.SpendsMultisig()
+	if inputStats.IsSpendingMultisig {
+		switch inputStats.Type {
+		case InP2SH_P2WSH:
+			_, inputStats.MultiSigM, inputStats.MultiSigN = input.GetNestedP2WSHRedeemScript().IsMultisigScript()
+		case InP2SH:
+			_, inputStats.MultiSigM, inputStats.MultiSigN = input.GetP2SHRedeemScript().IsMultisigScript()
+		case InP2WSH:
+			_, inputStats.MultiSigM, inputStats.MultiSigN = input.GetP2WSHRedeemScript().IsMultisigScript()
+		}
+	}
+
+	inputStats.SigStats = make([]*SignatureStats, 0)
+	inputStats.PubKeyStats = make([]*PubKeyStats, 0)
+	inputStats.OpCodes = make([]OpCode, 0)
+	if len(input.ScriptSig) > 0 {
+		parsedScriptSig := input.ScriptSig.Parse()
+		for _, opCode := range parsedScriptSig {
+			if opCode.IsSignature() {
+				ss := opCode.SignatureStats()
+				inputStats.SigStats = append(inputStats.SigStats, ss)
+			} else if opCode.IsPubKey() {
+				pks := opCode.PubKeyStats()
+				inputStats.PubKeyStats = append(inputStats.PubKeyStats, pks)
+			} else if opCode.OpCode.IsDataPushOpCode() {
+				parsedOpCodeScript := BitcoinScript(opCode.PushedData).Parse()
+				for _, inScriptOpcode := range parsedOpCodeScript {
+					if inScriptOpcode.IsSignature() {
+						ss := inScriptOpcode.SignatureStats()
+						inputStats.SigStats = append(inputStats.SigStats, ss)
+					} else if inScriptOpcode.IsPubKey() {
+						pks := inScriptOpcode.PubKeyStats()
+						inputStats.PubKeyStats = append(inputStats.PubKeyStats, pks)
+					}
+				}
+			}
+			inputStats.OpCodes = append(inputStats.OpCodes, opCode.OpCode)
+		}
+	}
+
+	if len(input.Witness) > 0 {
+		for _, witnessElement := range input.Witness {
+			if witnessElement.IsSignature() {
+				ss := witnessElement.SignatureStats()
+				inputStats.SigStats = append(inputStats.SigStats, ss)
+			} else if witnessElement.IsPubKey() {
+				pks := witnessElement.PubKeyStats()
+				inputStats.PubKeyStats = append(inputStats.PubKeyStats, pks)
+			} else if witnessElement.OpCode.IsDataPushOpCode() {
+				parsedWitnessScript := BitcoinScript(witnessElement.PushedData).Parse()
+				for _, witnessOpCode := range parsedWitnessScript {
+					if witnessOpCode.IsSignature() {
+						ss := witnessOpCode.SignatureStats()
+						inputStats.SigStats = append(inputStats.SigStats, ss)
+					} else if witnessOpCode.IsPubKey() {
+						pks := witnessOpCode.PubKeyStats()
+						inputStats.PubKeyStats = append(inputStats.PubKeyStats, pks)
+					}
+					inputStats.OpCodes = append(inputStats.OpCodes, witnessOpCode.OpCode)
+				}
+			}
+			inputStats.OpCodes = append(inputStats.OpCodes, witnessElement.OpCode)
+		}
+	}
+	return inputStats
+}
+
+// SignatureStats contains stats about a signature
+type SignatureStats struct {
+	Length      int
+	IsECDSA     bool
+	IsStrictDER bool
+	HasLowR     bool
+	HasLowS     bool
+	SigHash     byte
+}
+
+// SignatureStats returns a populated *SignatureStats struct for the signature
+// The caller must make sure that the *ParsedOpCode is a signature.
+func (sigOpCode *ParsedOpCode) SignatureStats() *SignatureStats {
+	sigStats := &SignatureStats{}
+	sigStats.Length = len(sigOpCode.PushedData)
+	sigStats.IsECDSA = sigOpCode.IsECDSASignature(false)
+	if sigStats.IsECDSA {
+		sigStats.IsStrictDER = sigOpCode.IsECDSASignature(true)
+		ecdsaSig, ok := DeserializeECDSASignature(sigOpCode.PushedData[:sigStats.Length-1], false)
+		if !ok {
+			panic("Signature should evaluate to ok here")
+		}
+		sigStats.HasLowR = ecdsaSig.HasLowR()
+		sigStats.HasLowS = ecdsaSig.HasLowS()
+	}
+	sigStats.SigHash = sigOpCode.GetSigHash()
+	return sigStats
+}
+
+// PubKeyStats contains stats about a PubKey
+type PubKeyStats struct {
+	IsCompressed bool
+}
+
+// PubKeyStats returns a populated *PubKeyStats struct for the PubKey
+// The caller must make sure that the *ParsedOpCode is a pubkey.
+func (sigOpCode *ParsedOpCode) PubKeyStats() *PubKeyStats {
+	pkStats := &PubKeyStats{}
+	pkStats.IsCompressed = sigOpCode.IsCompressedPubKey()
+	return pkStats
+}
+
+// OutputStats contains stats about an output
+type OutputStats struct {
+	Type         OutputType
+	TypeString   string
+	Amount       int64
+	OpReturnData []byte
+	PubKeyStats  []*PubKeyStats // P2MS outputs have pubkeys
+	OpCodes      []OpCode
+}
+
+// OutputStats returns a populated *OutputStats struct for an output
+func (out *Output) OutputStats() *OutputStats {
+	outStats := &OutputStats{}
+	outStats.Type = out.GetType()
+	outStats.TypeString = out.GetType().String()
+	outStats.Amount = out.Value
+	if outStats.Type == OutOPRETURN {
+		_, opCode := out.GetOPReturnData()
+		outStats.OpReturnData = opCode.PushedData
+	}
+
+	outStats.PubKeyStats = make([]*PubKeyStats, 0)
+	outStats.OpCodes = make([]OpCode, 0)
+	parsedScriptPubKey := out.ScriptPubKey.Parse()
+	for _, opCode := range parsedScriptPubKey {
+		if opCode.IsPubKey() {
+			pks := opCode.PubKeyStats()
+			outStats.PubKeyStats = append(outStats.PubKeyStats, pks)
+		}
+		outStats.OpCodes = append(outStats.OpCodes, opCode.OpCode)
+	}
+	return outStats
+}


### PR DESCRIPTION
This adds a txstats object that returns statistics about a transaction.

Additionally, an usage example is provided in `examples/txstat/`.